### PR TITLE
feature: move css higher in waterfall order

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,4 @@
 import "./src/styles/global.scss";
+require('typeface-droid-serif');
+require('typeface-roboto');
+require('typeface-source-sans-pro');

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,16 +12,8 @@ module.exports = {
   },
   /* Your site config here */
   plugins: [
-    {
-      resolve: 'gatsby-plugin-web-font-loader',
-      options: {
-        google: {
-          families: ['MuseoModerno', 'Roboto', 'Droid Serif', 'Source Sans Pro']
-        },
-        icon: "../src/pages/images/realizeLogoPNG.png"
-      }
-    },
-    `gatsby-plugin-sass`, 
+    `gatsby-plugin-sass`,
+    `gatsby-plugin-styled-components`,
     // `gatsby-plugin-react-helmet`
   ]
 }

--- a/package.json
+++ b/package.json
@@ -14,16 +14,18 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
+    "babel-plugin-styled-components": "^1.10.7",
     "gatsby": "^2.22.15",
     "gatsby-plugin-manifest": "^2.4.11",
     "gatsby-plugin-react-helmet": "^3.3.4",
     "gatsby-plugin-sass": "^2.3.4",
-    "gatsby-plugin-web-font-loader": "^1.0.4",
+    "gatsby-plugin-styled-components": "^3.3.4",
     "node-sass": "^4.14.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-github-btn": "^1.2.0",
-    "react-helmet": "^6.1.0"
+    "react-helmet": "^6.1.0",
+    "styled-components": "^5.1.1"
   },
   "devDependencies": {
     "prettier": "2.0.5"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "react-dom": "^16.12.0",
     "react-github-btn": "^1.2.0",
     "react-helmet": "^6.1.0",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "typeface-droid-serif": "0.0.44",
+    "typeface-roboto": "0.0.75",
+    "typeface-source-sans-pro": "^1.1.5"
   },
   "devDependencies": {
     "prettier": "2.0.5"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,22 +7,31 @@ import Demo from './components/Demo.js';
 import About from './components/About.js';
 import Authors from './components/Authors.js';
 import Contribute from './components/Contribute.js';
+import { createGlobalStyle } from 'styled-components';
 
+const GlobalStyle = createGlobalStyle`
+  @import url('https://fonts.googleapis.com/css2?family=MuseoModerno&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Droid+Serif&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro&display=swap');
+`;
 
 export default function Home() {
   return (
-    <div className="container">
-      <Nav />
-      <Spacer />
-      <Title />
-      <About />
-      <Installation />
-      <Demo />   
-      <Authors />
-      <Contribute />
-    </div>  
-
-    )
+    <>
+      <GlobalStyle />
+      <div className="container">
+        <Nav />
+        <Spacer />
+        <Title />
+        <About />
+        <Installation />
+        <Demo />
+        <Authors />
+        <Contribute />
+      </div>
+    </>
+  )
 }
 
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,9 +11,6 @@ import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
   @import url('https://fonts.googleapis.com/css2?family=MuseoModerno&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=Droid+Serif&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro&display=swap');
 `;
 
 export default function Home() {


### PR DESCRIPTION
#Changes made:
1. self host 3 available fonts from github's typeface packages section
2. remove gatsby font loader (loads asynchronously, creates visual jank on first paint
3. create global styling with styled components

more info [here](https://markoskon.com/extremely-fast-load-time-with-gatsby-and-self-hosted-fonts/)

#steps to reproduce:
1. pull master & npm i then npm run develop/gatsby develop
2. ensure no visual stuttering/jank on first paint
3. ensure all network requests successfully resolving (no 400's)